### PR TITLE
CKAN 2.4 compatibility and tests refactoring

### DIFF
--- a/ckanext/userdatasets/logic/auth/create.py
+++ b/ckanext/userdatasets/logic/auth/create.py
@@ -23,7 +23,12 @@ def package_create(context, data_dict):
 
 def resource_create(context, data_dict):
     user = context['auth_user_obj']
+    
+    # ckan.logic.auth._get_object() expects 'id', not 'package_id' as key
+    package_id = data_dict.get('package_id')
+    data_dict.update({'id': package_id})
     package = get_package_object(context, data_dict)
+    
     if user_owns_package_as_member(user, package):
         return {'success': True}
     elif user_is_member_of_package_org(user, package):

--- a/ckanext/userdatasets/logic/auth/create.py
+++ b/ckanext/userdatasets/logic/auth/create.py
@@ -45,9 +45,9 @@ def resource_view_create(context, data_dict):
     else:
         dc = data_dict
     resource = get_resource_object(context, dc)
-    if user_owns_package_as_member(user, resource.resource_group.package):
+    if user_owns_package_as_member(user, resource.package):
         return {'success': True}
-    elif user_is_member_of_package_org(user, resource.resource_group.package):
+    elif user_is_member_of_package_org(user, resource.package):
         return {'success': False}
 
     fallback = get_default_auth('create', 'resource_view_create')

--- a/ckanext/userdatasets/logic/auth/delete.py
+++ b/ckanext/userdatasets/logic/auth/delete.py
@@ -18,7 +18,8 @@ def package_delete(context, data_dict):
 def resource_delete(context, data_dict):
     user = context['auth_user_obj']
     resource = get_resource_object(context, data_dict)
-    package = resource.resource_group.package
+    package = resource.package
+    
     if user_owns_package_as_member(user, package):
         return {'success': True}
     elif user_is_member_of_package_org(user, package):
@@ -32,9 +33,9 @@ def resource_view_delete(context, data_dict):
     user = context['auth_user_obj']
     resource_view = get_resource_view_object(context, data_dict)
     resource = get_resource_object(context, {'id': resource_view.resource_id})
-    if user_owns_package_as_member(user, resource.resource_group.package):
+    if user_owns_package_as_member(user, resource.package):
         return {'success': True}
-    elif user_is_member_of_package_org(user, resource.resource_group.package):
+    elif user_is_member_of_package_org(user, resource.package):
         return {'success': False}
 
     fallback = get_default_auth('delete', 'resource_view_delete')

--- a/ckanext/userdatasets/logic/auth/update.py
+++ b/ckanext/userdatasets/logic/auth/update.py
@@ -17,7 +17,7 @@ def package_update(context, data_dict):
 def resource_update(context, data_dict):
     user = context['auth_user_obj']
     resource = get_resource_object(context, data_dict)
-    package = resource.resource_group.package
+    package = resource.package
     if user_owns_package_as_member(user, package):
         return {'success': True}
     elif user_is_member_of_package_org(user, package):
@@ -31,9 +31,9 @@ def resource_view_update(context, data_dict):
     user = context['auth_user_obj']
     resource_view = get_resource_view_object(context, data_dict)
     resource = get_resource_object(context, {'id': resource_view.resource_id})
-    if user_owns_package_as_member(user, resource.resource_group.package):
+    if user_owns_package_as_member(user, resource.package):
         return {'success': True}
-    elif user_is_member_of_package_org(user, resource.resource_group.package):
+    elif user_is_member_of_package_org(user, resource.package):
         return {'success': False}
 
     fallback = get_default_auth('update', 'resource_view_update')

--- a/ckanext/userdatasets/tests/test_auth_actions_unit.py
+++ b/ckanext/userdatasets/tests/test_auth_actions_unit.py
@@ -225,7 +225,7 @@ class TestAuthActionsUnit:
                 'result': 'fallback'
             },
         ]
-        mock_get_resource.return_value = SMock(resource_group=SMock(package=1))
+        mock_get_resource.return_value = SMock(package=1)
         mock_default_auth.return_value = Mock(return_value='fallback')
         for t in tests:
             mock_user_owns.return_value = t['user_owns']
@@ -273,7 +273,7 @@ class TestAuthActionsUnit:
                 'result': 'fallback'
             },
         ]
-        mock_get_resource.return_value = SMock(resource_group=SMock(package=1))
+        mock_get_resource.return_value = SMock(package=1)
         mock_default_auth.return_value = Mock(return_value='fallback')
         for t in tests:
             mock_user_owns.return_value = t['user_owns']
@@ -312,7 +312,7 @@ class TestAuthActionsUnit:
             },
         ]
         mock_get_resource_view.return_value = SMock(resource_id=1)
-        mock_get_resource.return_value = SMock(resource_group=SMock(package=1))
+        mock_get_resource.return_value = SMock(package=1)
         mock_default_auth.return_value = Mock(return_value='fallback')
         for t in tests:
             mock_user_owns.return_value = t['user_owns']
@@ -360,7 +360,7 @@ class TestAuthActionsUnit:
                 'result': 'fallback'
             },
         ]
-        mock_get_resource.return_value = SMock(resource_group=SMock(package=1))
+        mock_get_resource.return_value = SMock(package=1)
         mock_default_auth.return_value = Mock(return_value='fallback')
         for t in tests:
             mock_user_owns.return_value = t['user_owns']
@@ -399,9 +399,10 @@ class TestAuthActionsUnit:
             },
         ]
         mock_get_resource_view.return_value = SMock(resource_id=1)
-        mock_get_resource.return_value = SMock(resource_group=SMock(package=1))
+        mock_get_resource.return_value = SMock(package=1)
         mock_default_auth.return_value = Mock(return_value='fallback')
         for t in tests:
             mock_user_owns.return_value = t['user_owns']
             mock_user_is_member.return_value = t['user_is_member']
             assert_equal(resource_view_delete({'auth_user_obj': 1}, {'resource_id':1}), t['result'])
+

--- a/ckanext/userdatasets/tests/test_functional.py
+++ b/ckanext/userdatasets/tests/test_functional.py
@@ -1,78 +1,68 @@
-"""Functional tests for the userdatasets plugin
+"""
+Functional tests for the userdatasets plugin
 
-    These test ensure that the plugins behave as expected within CKAN. We refer to 'member', 'editor' and 'admin' as
-    users with the member, editor or admin role respectively in a given organization.
+These test ensure that the plugins behave as expected within CKAN. We refer
+to 'member', 'editor' and 'admin' as users with the member, editor or admin
+role respectively in a given organization.
 
-    For each type of object(package, resource, resource_view) this tests that:
-        - a given user can create such objects and edit/delete their own objects in an organization of which
-          they are a member;
-        - editors can edit/delete objects created by members;
-        - members cannot edit/delete objects created by other members;
-        - users cannot create such object in organizations where they are not members.
+For each type of object(package, resource, resource_view) this tests that:
 
-    The actual implementation of the auth functions are tested in a separate unit test.
+    - a given user can create such objects and edit/delete their own objects in
+      an organization of which they are a member;
+
+    - editors can edit/delete objects created by members;
+
+    - members cannot edit/delete objects created by other members;
+
+    - users cannot create such object in organizations where they are not
+      members.
+
+The actual implementation of the auth functions are tested in a separate
+unit test.
+
 """
 import paste.fixture
 import pylons.test
-
 import ckan.model as model
-import ckan.tests as tests
-import ckan.plugins as plugins
 
-from nose import SkipTest
+# don't use ckan.tests here!
+import ckan.tests.legacy as tests
+
+import ckan.plugins as plugins
 from nose.tools import assert_equal
+import ckan.tests.factories as factories
+
 
 class TestUserdataSetsFunc(object):
     """Functional tests for the ckanext-userdatasets plugin"""
+
     @classmethod
     def setup_class(cls):
-        # Check whether this version of CKAN has resource views.  Remove this test when branch 1251 gets merged into CKAN master.
-        try:
-            from ckan.logic.action.create import resource_view_create
-            cls.has_resource_views = True
-        except ImportError:
-            cls.has_resource_views = False
+
         # Create the CKAN app and load our plugins
         cls.app = paste.fixture.TestApp(pylons.test.pylonsapp)
-        plugins.load('userdatasets')
-        if cls.has_resource_views:
-            plugins.load('text_preview')
+        plugins.load('userdatasets', 'text_view')
 
     @classmethod
     def teardown_class(cls):
         # Unload our plugin
-        plugins.unload('userdatasets')
+        plugins.unload('userdatasets', 'text_view')
 
     def setup(self):
-        # Create a sysadmin user
-        self.sysadmin = model.User(name='test_sysadmin', sysadmin=True)
-        model.Session.add(self.sysadmin)
-        model.Session.commit()
-        model.Session.remove()
-        # Create three users: test_member_1, test_member_2 and test_editor
-        self.users = {}
-        for name in ['test_member_1', 'test_member_2', 'test_editor']:
-            self.users[name] = tests.call_action_api(self.app, 'user_create',
-                                                     apikey=self.sysadmin.apikey,
-                                                     name=name,
-                                                     email='email',
-                                                     password='password')
-        # Create the organization test_org_1 of which test_member_1 and test_member_2 are
-        # members, and test_editor is an editor
-        users = [
-            {'name': 'test_member_1', 'capacity': 'member'},
-            {'name': 'test_member_2', 'capacity': 'member'},
-            {'name': 'test_editor', 'capacity': 'editor'},
-        ]
-        self.organizations = {}
-        self.organizations['test_org_1'] = tests.call_action_api(self.app, 'organization_create',
-                                               apikey=self.sysadmin.apikey,
-                                               name='test_org_1',
-                                               users=users)
-        # Create the organization test_org_2 with no members.
-        self.organizations['test_org_2'] = tests.call_action_api(self.app, 'organization_create',
-                                               apikey=self.sysadmin.apikey,
-                                               name='test_org_2')
+        """
+        Create users and organizations
+        """
+        self.sysadmin = factories.Sysadmin()
+        self.test_member_1 = factories.User()
+        self.test_member_2 = factories.User()
+        self.test_editor = factories.User()
+
+        users = [{'name': self.test_member_1['name'], 'capacity': 'member'},
+                 {'name': self.test_member_2['name'], 'capacity': 'member'},
+                 {'name': self.test_editor['name'], 'capacity': 'editor'}]
+
+        self.test_org_1 = factories.Organization(users=users)
+        self.test_org_2 = factories.Organization()
 
     def teardown(self):
         # Rebuild the db; each test starts clean.
@@ -80,204 +70,243 @@ class TestUserdataSetsFunc(object):
 
     def test_dataset(self):
         """Tests datasets"""
-        # Create a dataset test_pkg_1 in organization test_org_1 as member test_member_1
+
+        # Create a dataset test_pkg_1 in organization test_org_1 as member
+        # test_member_1
         pkg = tests.call_action_api(self.app, 'package_create',
-                                    apikey=self.users['test_member_1']['apikey'],
+                                    apikey=self.test_member_1['apikey'],
                                     name='test_pkg_1',
-                                    owner_org=self.organizations['test_org_1']['id'])
+                                    owner_org=self.test_org_1['id'])
         assert_equal(pkg['name'], 'test_pkg_1')
+
         # Update the dataset test_pkg_1 as member test_member_1
         pkg = tests.call_action_api(self.app, 'package_update',
-                                       apikey=self.users['test_member_1']['apikey'],
-                                       id=pkg['id'],
-                                       title='new title')
+                                    apikey=self.test_member_1['apikey'],
+                                    id=pkg['id'],
+                                    title='new title')
         assert_equal(pkg['title'], 'new title')
+
         # Update the dataset test_pkg_1 as member test_editor
         pkg = tests.call_action_api(self.app, 'package_update',
-                                       apikey=self.users['test_editor']['apikey'],
-                                       id=pkg['id'],
-                                       title='new title 2')
+                                    apikey=self.test_editor['apikey'],
+                                    id=pkg['id'],
+                                    title='new title 2')
         assert_equal(pkg['title'], 'new title 2')
+
         # Attempt to update test_pkg_1 as member test_member_2
         result = tests.call_action_api(self.app, 'package_update',
-                                       apikey=self.users['test_member_2']['apikey'],
+                                       apikey=self.test_member_2['apikey'],
                                        id=pkg['id'],
                                        description='new description',
                                        status=403)
         assert_equal(result['__type'], 'Authorization Error')
+
         # Attempt to delete test_pkg_1 as member test_member_2
         result = tests.call_action_api(self.app, 'package_delete',
-                                       apikey=self.users['test_member_2']['apikey'],
+                                       apikey=self.test_member_2['apikey'],
                                        id=pkg['id'],
                                        status=403)
         assert_equal(result['__type'], 'Authorization Error')
+
         # Delete test_pkg_1 as member test_member_1
         result = tests.call_action_api(self.app, 'package_delete',
-                                       apikey=self.users['test_member_1']['apikey'],
+                                       apikey=self.test_member_1['apikey'],
                                        id=pkg['id'])
         assert_equal(result, None)
-        # Create a dataset test_pkg_2 in organization test_org_1 as member test_member_1
+
+        # Create a dataset test_pkg_2 in organization test_org_1 as member
+        # test_member_1
         pkg_2 = tests.call_action_api(self.app, 'package_create',
-                                      apikey=self.users['test_member_1']['apikey'],
+                                      apikey=self.test_member_1['apikey'],
                                       name='test_pkg_2',
-                                      owner_org=self.organizations['test_org_1']['id'])
+                                      owner_org=self.test_org_1['id'])
         assert_equal(pkg_2['name'], 'test_pkg_2')
+
         # Delete test_pkg_2 as member test_editor
         result = tests.call_action_api(self.app, 'package_delete',
-                                       apikey=self.users['test_editor']['apikey'],
+                                       apikey=self.test_editor['apikey'],
                                        id=pkg_2['id'])
         assert_equal(result, None)
-        # Attempt to create a dataset test_pkg_3 in organization test_org_2 as member test_member_1
+
+        # Attempt to create a dataset test_pkg_3 in organization test_org_2 as
+        # member test_member_1
         result = tests.call_action_api(self.app, 'package_create',
-                                    apikey=self.users['test_member_1']['apikey'],
-                                    name='test_pkg_3',
-                                    owner_org=self.organizations['test_org_2']['id'],
-                                    status=403)
+                                       apikey=self.test_member_1['apikey'],
+                                       name='test_pkg_3',
+                                       owner_org=self.test_org_2['id'],
+                                       status=403)
         assert_equal(result['__type'], 'Authorization Error')
 
     def test_resource(self):
         """Tests resources"""
-        # Create a dataset test_pkg_1 in organization test_org_1 as member test_member_1
+
+        # Create a dataset test_pkg_1 in organization test_org_1 as member
+        # test_member_1
         pkg = tests.call_action_api(self.app, 'package_create',
-                                    apikey=self.users['test_member_1']['apikey'],
+                                    apikey=self.test_member_1['apikey'],
                                     name='test_pkg_1',
-                                    owner_org=self.organizations['test_org_1']['id'])
+                                    owner_org=self.test_org_1['id'])
         assert_equal(pkg['name'], 'test_pkg_1')
+
         # Create a resource test_res_1 under test_pkg_1 as member test_member_1
         res_1 = tests.call_action_api(self.app, 'resource_create',
-                                      apikey=self.users['test_member_1']['apikey'],
+                                      apikey=self.test_member_1['apikey'],
                                       url='http://test_res_1.test.com',
                                       package_id=pkg['id'])
         assert_equal(res_1['url'], 'http://test_res_1.test.com')
+
         # Update the resource test_res_1 as member test_member_1
         res_1 = tests.call_action_api(self.app, 'resource_update',
-                                      apikey=self.users['test_member_1']['apikey'],
+                                      apikey=self.test_member_1['apikey'],
                                       id=res_1['id'],
                                       url='http://test_res_1.test.com',
                                       description='test description')
         assert_equal(res_1['description'], 'test description')
+
         # Update the resource test_res_1 as member test_editor
         res_1 = tests.call_action_api(self.app, 'resource_update',
-                                      apikey=self.users['test_editor']['apikey'],
+                                      apikey=self.test_editor['apikey'],
                                       id=res_1['id'],
                                       url='http://test_res_1.test.com',
                                       description='test description 2')
         assert_equal(res_1['description'], 'test description 2')
+
         # Attempt to update test_res_1 as member test_member_2
         result = tests.call_action_api(self.app, 'resource_update',
-                                       apikey=self.users['test_member_2']['apikey'],
+                                       apikey=self.test_member_2['apikey'],
                                        id=res_1['id'],
                                        url='http://test_res_1.test.com',
                                        description='test description 3',
                                        status=403)
         assert_equal(result['__type'], 'Authorization Error')
+
         # Attempt to delete test_res_1 as member test_member_2
         result = tests.call_action_api(self.app, 'resource_delete',
-                                       apikey=self.users['test_member_2']['apikey'],
+                                       apikey=self.test_member_2['apikey'],
                                        id=res_1['id'],
                                        status=403)
         assert_equal(result['__type'], 'Authorization Error')
-        # Attempt to create a resource test_res_2 under test_pkg_1 as member test_member_2
+
+        # Attempt to create a resource test_res_2 under test_pkg_1 as member
+        # test_member_2
         result = tests.call_action_api(self.app, 'resource_create',
-                                      apikey=self.users['test_member_2']['apikey'],
-                                      url='http://test_res_2.test.com',
-                                      package_id=pkg['id'],
-                                      status=403)
+                                       apikey=self.test_member_2['apikey'],
+                                       url='http://test_res_2.test.com',
+                                       package_id=pkg['id'],
+                                       status=403)
         assert_equal(result['__type'], 'Authorization Error')
+
         # Delete test_res_1 as member test_member_1
         result = tests.call_action_api(self.app, 'resource_delete',
-                                       apikey=self.users['test_member_1']['apikey'],
+                                       apikey=self.test_member_1['apikey'],
                                        id=res_1['id'])
         assert_equal(result, None)
+
         # Create a resource test_res_3 under test_pkg_1 as member test_member_1
         res_3 = tests.call_action_api(self.app, 'resource_create',
-                                      apikey=self.users['test_member_1']['apikey'],
+                                      apikey=self.test_member_1['apikey'],
                                       url='http://test_res_3.test.com',
                                       package_id=pkg['id'])
         assert_equal(res_3['url'], 'http://test_res_3.test.com')
+
         # Delete test_res_3 as member test_editor
         result = tests.call_action_api(self.app, 'resource_delete',
-                                       apikey=self.users['test_editor']['apikey'],
+                                       apikey=self.test_editor['apikey'],
                                        id=res_3['id'])
         assert_equal(result, None)
 
     def test_resource_view(self):
         """Tests resource views"""
-        # Only do this if this version of CKAN has resource views.
-        if not self.has_resource_views:
-            raise SkipTest("This version of CKAN does not have resource views")
-        # Create a dataset test_pkg_1 in organization test_org_1 as member test_member_1
+
+        # Create a dataset test_pkg_1 in organization test_org_1 as member
+        # test_member_1
         pkg = tests.call_action_api(self.app, 'package_create',
-                                    apikey=self.users['test_member_1']['apikey'],
+                                    apikey=self.test_member_1['apikey'],
                                     name='test_pkg_1',
-                                    owner_org=self.organizations['test_org_1']['id'])
+                                    owner_org=self.test_org_1['id'])
         assert_equal(pkg['name'], 'test_pkg_1')
+
         # Create a resource test_res_1 under test_pkg_1 as member test_member_1
         res_1 = tests.call_action_api(self.app, 'resource_create',
-                                      apikey=self.users['test_member_1']['apikey'],
+                                      apikey=self.test_member_1['apikey'],
                                       url='http://test_res_1.test.com',
                                       package_id=pkg['id'])
         assert_equal(res_1['url'], 'http://test_res_1.test.com')
-        # Create a resource view test_view_1 under test_rest_1 as member test_member_1
+
+        # Create a resource view test_view_1 under test_rest_1 as member
+        # test_member_1
         view_1 = tests.call_action_api(self.app, 'resource_view_create',
-                                       apikey=self.users['test_member_1']['apikey'],
+                                       apikey=self.test_member_1['apikey'],
                                        resource_id=res_1['id'],
                                        title='test view',
-                                       view_type='text')
+                                       view_type='text_view',
+                                       status=200)
         assert_equal(view_1['title'], 'test view')
+
         # Update the resource view test_view_1 as test_member_1
         view_1 = tests.call_action_api(self.app, 'resource_view_update',
-                                       apikey=self.users['test_member_1']['apikey'],
+                                       apikey=self.test_member_1['apikey'],
                                        id=view_1['id'],
                                        title='test view',
                                        description='test description',
-                                       view_type='text')
+                                       view_type='text_view')
         assert_equal(view_1['description'], 'test description')
+
         # Update the resource view test_view_1 as test_editor
         view_1 = tests.call_action_api(self.app, 'resource_view_update',
-                                       apikey=self.users['test_editor']['apikey'],
+                                       apikey=self.test_editor['apikey'],
+                                       resource_id=res_1['id'],
                                        id=view_1['id'],
                                        title='test view',
                                        description='test description 2',
-                                       view_type='text')
+                                       view_type='text_view')
         assert_equal(view_1['description'], 'test description 2')
+
         # Attempt to update test_view_1 as test_member_2
         result = tests.call_action_api(self.app, 'resource_view_update',
-                                       apikey=self.users['test_member_2']['apikey'],
+                                       apikey=self.test_member_2['apikey'],
                                        id=view_1['id'],
                                        title='test view',
                                        description='test description 3',
-                                       view_type='text',
+                                       view_type='text_view',
                                        status=403)
         assert_equal(result['__type'], 'Authorization Error')
+
         # Attempt to delete test_view_1 as test_member_2
         result = tests.call_action_api(self.app, 'resource_view_delete',
-                                       apikey=self.users['test_member_2']['apikey'],
+                                       apikey=self.test_member_2['apikey'],
                                        id=view_1['id'],
                                        status=403)
         assert_equal(result['__type'], 'Authorization Error')
-        # Attempt to create a resource view test_view_2 under test_res_1 as test_member_2
+
+        # Attempt to create a resource view test_view_2 under test_res_1 as
+        # test_member_2
         result = tests.call_action_api(self.app, 'resource_view_create',
-                                       apikey=self.users['test_member_2']['apikey'],
+                                       apikey=self.test_member_2['apikey'],
                                        resource_id=res_1['id'],
                                        title='test view 2',
-                                       view_type='text',
+                                       view_type='text_view',
                                        status=403)
         assert_equal(result['__type'], 'Authorization Error')
+
         # Delete test_view_1 as test_member_1
         result = tests.call_action_api(self.app, 'resource_view_delete',
-                                       apikey=self.users['test_member_1']['apikey'],
+                                       apikey=self.test_member_1['apikey'],
                                        id=view_1['id'])
         assert_equal(result, None)
-        # Create a resource view test_view_3 under test_rest_1 as member test_member_1
+
+        # Create a resource view test_view_3 under test_rest_1 as member
+        # test_member_1
         view_3 = tests.call_action_api(self.app, 'resource_view_create',
-                                       apikey=self.users['test_member_1']['apikey'],
+                                       apikey=self.test_member_1['apikey'],
                                        resource_id=res_1['id'],
                                        title='test view 3',
-                                       view_type='text')
+                                       view_type='text_view')
         assert_equal(view_3['title'], 'test view 3')
+
         # Delete test_view_3 as member test_editor
         result = tests.call_action_api(self.app, 'resource_view_delete',
-                                       apikey=self.users['test_editor']['apikey'],
+                                       apikey=self.test_editor['apikey'],
                                        id=view_3['id'])
         assert_equal(result, None)
+

--- a/ckanext/userdatasets/tests/test_get_default_unit.py
+++ b/ckanext/userdatasets/tests/test_get_default_unit.py
@@ -2,11 +2,31 @@
 
 import importlib
 from nose.tools import assert_is
+import paste.fixture
+import pylons.test
+import ckan.model as model
+import ckan.plugins
 
 from ckanext.userdatasets.plugin import get_default_auth, get_default_action
 
-class TestGetDefaultUnit:
+
+class TestGetDefaultUnit(object):
     """Unit tests on the the get_default_auth/action functions in plugin.py"""
+
+# We have to setup full Pylons stack here since 'get_default_action' needs to
+# load the plugin which sets the config dict
+
+    @classmethod
+    def setup_class(cls):
+        cls.app = paste.fixture.TestApp(pylons.test.pylonsapp)
+        ckan.plugins.load('userdatasets')
+
+    def teardown(self):
+        model.repo.rebuild_db()
+
+    @classmethod
+    def teardown_class(cls):
+        ckan.plugins.unload('userdatasets')
 
     def test_get_default_auth(self):
         for action in ['create', 'update', 'delete']:


### PR DESCRIPTION
The PR adds CKAN 2.4 compatibility. It removes the old `resource_group` attribute, which has been the main reason the plugin did not work with CKAN 2.4. It also adapts the tests to this, and does some test refactoring (some also due to CKAN 2.4 issues).

Tests are running fine, and the plugin now works fully with CKAN 2.4. However, we probably lost backward compatibility. 
