### PR TITLE
Use chained auth to handle org member permissions for create/update/delete

### DIFF
--- a/ckanext/userdatasets/logic/auth/create.py
+++ b/ckanext/userdatasets/logic/auth/create.py
@@ -9,7 +9,6 @@ from ckan.logic.auth import get_package_object, get_resource_object
 from ckan.plugins import toolkit
 
 from ckanext.userdatasets.logic.auth.auth import (
-    user_is_member_of_package_org,
     user_owns_package_as_member,
 )
 
@@ -38,8 +37,6 @@ def resource_create(next_auth, context, data_dict):
     package = get_package_object(context, {'id': data_dict['package_id']})
     if user_owns_package_as_member(user, package):
         return {'success': True}
-    elif user_is_member_of_package_org(user, package):
-        return {'success': False}
     return next_auth(context, data_dict)
 
 
@@ -58,7 +55,5 @@ def resource_view_create(next_auth, context, data_dict):
     resource = get_resource_object(context, dc)
     if user_owns_package_as_member(user, resource.package):
         return {'success': True}
-    elif user_is_member_of_package_org(user, resource.package):
-        return {'success': False}
 
     return next_auth(context, data_dict)

--- a/ckanext/userdatasets/logic/auth/create.py
+++ b/ckanext/userdatasets/logic/auth/create.py
@@ -34,7 +34,18 @@ def package_create(next_auth, context, data_dict):
 @toolkit.chained_auth_function
 def resource_create(next_auth, context, data_dict):
     user = context['auth_user_obj']
-    package = get_package_object(context, {'id': data_dict['package_id']})
+
+    # can be routed from other auths without changing the params correctly
+    package_id = data_dict.get('package_id')
+    if not package_id and data_dict.get('id'):
+        resource = get_resource_object(context, data_dict)
+        package_id = resource.package_id
+    if not package_id:
+        raise toolkit.ValidationError(
+            toolkit._('No dataset id provided, cannot check auth.')
+        )
+
+    package = get_package_object(context, {'id': package_id})
     if user_owns_package_as_member(user, package):
         return {'success': True}
     return next_auth(context, data_dict)

--- a/ckanext/userdatasets/logic/auth/delete.py
+++ b/ckanext/userdatasets/logic/auth/delete.py
@@ -9,7 +9,6 @@ from ckan.plugins import toolkit
 
 from ckanext.userdatasets.logic.auth.auth import (
     get_resource_view_object,
-    user_is_member_of_package_org,
     user_owns_package_as_member,
 )
 
@@ -32,8 +31,6 @@ def resource_delete(next_auth, context, data_dict):
     package = resource.package
     if user_owns_package_as_member(user, package):
         return {'success': True}
-    elif user_is_member_of_package_org(user, package):
-        return {'success': False}
 
     return next_auth(context, data_dict)
 
@@ -45,7 +42,5 @@ def resource_view_delete(next_auth, context, data_dict):
     resource = get_resource_object(context, {'id': resource_view.resource_id})
     if user_owns_package_as_member(user, resource.package):
         return {'success': True}
-    elif user_is_member_of_package_org(user, resource.package):
-        return {'success': False}
 
     return next_auth(context, data_dict)

--- a/ckanext/userdatasets/logic/auth/update.py
+++ b/ckanext/userdatasets/logic/auth/update.py
@@ -9,7 +9,6 @@ from ckan.plugins import toolkit
 
 from ckanext.userdatasets.logic.auth.auth import (
     get_resource_view_object,
-    user_is_member_of_package_org,
     user_owns_package_as_member,
 )
 
@@ -31,8 +30,6 @@ def resource_update(next_auth, context, data_dict):
     package = resource.package
     if user_owns_package_as_member(user, package):
         return {'success': True}
-    elif user_is_member_of_package_org(user, package):
-        return {'success': False}
 
     return next_auth(context, data_dict)
 
@@ -44,7 +41,5 @@ def resource_view_update(next_auth, context, data_dict):
     resource = get_resource_object(context, {'id': resource_view.resource_id})
     if user_owns_package_as_member(user, resource.package):
         return {'success': True}
-    elif user_is_member_of_package_org(user, resource.package):
-        return {'success': False}
 
     return next_auth(context, data_dict)

--- a/tests/test_auth_actions_unit.py
+++ b/tests/test_auth_actions_unit.py
@@ -162,12 +162,9 @@ class TestAuthActionsUnit(object):
             result = package_create(mock_default_auth, t['context'], t['data_dict'])
             assert result == t['result']
 
-    @patch('ckanext.userdatasets.logic.auth.create.user_is_member_of_package_org')
     @patch('ckanext.userdatasets.logic.auth.create.user_owns_package_as_member')
     @patch('ckanext.userdatasets.logic.auth.create.get_package_object')
-    def test_resource_create(
-        self, mock_get_package, mock_user_owns, mock_user_is_member
-    ):
+    def test_resource_create(self, mock_get_package, mock_user_owns):
         """
         Test ckanext.userdatasets.logic.auth.create.resource_create.
 
@@ -175,25 +172,21 @@ class TestAuthActionsUnit(object):
         """
         tests = [
             {'user_owns': True, 'user_is_member': True, 'result': {'success': True}},
-            {'user_owns': False, 'user_is_member': True, 'result': {'success': False}},
+            {'user_owns': False, 'user_is_member': True, 'result': 'fallback'},
             {'user_owns': False, 'user_is_member': False, 'result': 'fallback'},
         ]
         mock_get_package.return_value = 1
         for t in tests:
             mock_user_owns.return_value = t['user_owns']
-            mock_user_is_member.return_value = t['user_is_member']
             mock_default_auth = MagicMock(return_value='fallback')
             result = resource_create(
                 mock_default_auth, {'auth_user_obj': 1}, MagicMock()
             )
             assert result == t['result']
 
-    @patch('ckanext.userdatasets.logic.auth.create.user_is_member_of_package_org')
     @patch('ckanext.userdatasets.logic.auth.create.user_owns_package_as_member')
     @patch('ckanext.userdatasets.logic.auth.create.get_resource_object')
-    def test_resource_view_create(
-        self, mock_get_resource, mock_user_owns, mock_user_is_member
-    ):
+    def test_resource_view_create(self, mock_get_resource, mock_user_owns):
         """
         Test ckanext.userdatasets.logic.auth.create.resource_view_create.
 
@@ -202,13 +195,12 @@ class TestAuthActionsUnit(object):
 
         tests = [
             {'user_owns': True, 'user_is_member': True, 'result': {'success': True}},
-            {'user_owns': False, 'user_is_member': True, 'result': {'success': False}},
+            {'user_owns': False, 'user_is_member': True, 'result': 'fallback'},
             {'user_owns': False, 'user_is_member': False, 'result': 'fallback'},
         ]
         mock_get_resource.return_value = MagicMock(package=1)
         for t in tests:
             mock_user_owns.return_value = t['user_owns']
-            mock_user_is_member.return_value = t['user_is_member']
             mock_default_auth = MagicMock(return_value='fallback')
             result = resource_view_create(
                 mock_default_auth, {'auth_user_obj': 1}, {'resource_id': 1}
@@ -232,12 +224,9 @@ class TestAuthActionsUnit(object):
         result = package_update(mock_default_auth, {'auth_user_obj': 1}, MagicMock())
         assert result == 'fallback'
 
-    @patch('ckanext.userdatasets.logic.auth.update.user_is_member_of_package_org')
     @patch('ckanext.userdatasets.logic.auth.update.user_owns_package_as_member')
     @patch('ckanext.userdatasets.logic.auth.update.get_resource_object')
-    def test_resource_update(
-        self, mock_get_resource, mock_user_owns, mock_user_is_member
-    ):
+    def test_resource_update(self, mock_get_resource, mock_user_owns):
         """
         Test ckanext.userdatasets.logic.auth.create.resource_update.
 
@@ -245,29 +234,23 @@ class TestAuthActionsUnit(object):
         """
         tests = [
             {'user_owns': True, 'user_is_member': True, 'result': {'success': True}},
-            {'user_owns': False, 'user_is_member': True, 'result': {'success': False}},
+            {'user_owns': False, 'user_is_member': True, 'result': 'fallback'},
             {'user_owns': False, 'user_is_member': False, 'result': 'fallback'},
         ]
         mock_get_resource.return_value = MagicMock(package=1)
         for t in tests:
             mock_user_owns.return_value = t['user_owns']
-            mock_user_is_member.return_value = t['user_is_member']
             mock_default_auth = MagicMock(return_value='fallback')
             assert (
                 resource_update(mock_default_auth, {'auth_user_obj': 1}, {})
                 == t['result']
             )
 
-    @patch('ckanext.userdatasets.logic.auth.update.user_is_member_of_package_org')
     @patch('ckanext.userdatasets.logic.auth.update.user_owns_package_as_member')
     @patch('ckanext.userdatasets.logic.auth.update.get_resource_object')
     @patch('ckanext.userdatasets.logic.auth.update.get_resource_view_object')
     def test_resource_view_update(
-        self,
-        mock_get_resource_view,
-        mock_get_resource,
-        mock_user_owns,
-        mock_user_is_member,
+        self, mock_get_resource_view, mock_get_resource, mock_user_owns
     ):
         """
         Test ckanext.userdatasets.logic.auth.create.resource_view_update.
@@ -276,14 +259,13 @@ class TestAuthActionsUnit(object):
         """
         tests = [
             {'user_owns': True, 'user_is_member': True, 'result': {'success': True}},
-            {'user_owns': False, 'user_is_member': True, 'result': {'success': False}},
+            {'user_owns': False, 'user_is_member': True, 'result': 'fallback'},
             {'user_owns': False, 'user_is_member': False, 'result': 'fallback'},
         ]
         mock_get_resource_view.return_value = MagicMock(resource_id=1)
         mock_get_resource.return_value = MagicMock(package=1)
         for t in tests:
             mock_user_owns.return_value = t['user_owns']
-            mock_user_is_member.return_value = t['user_is_member']
             mock_default_auth = MagicMock(return_value='fallback')
             result = resource_view_update(
                 mock_default_auth, {'auth_user_obj': 1}, {'resource_id': 1}
@@ -307,12 +289,9 @@ class TestAuthActionsUnit(object):
         mock_user_owns.return_value = False
         assert package_delete(mock_default_auth, {'auth_user_obj': 1}, {}) == 'fallback'
 
-    @patch('ckanext.userdatasets.logic.auth.delete.user_is_member_of_package_org')
     @patch('ckanext.userdatasets.logic.auth.delete.user_owns_package_as_member')
     @patch('ckanext.userdatasets.logic.auth.delete.get_resource_object')
-    def test_resource_delete(
-        self, mock_get_resource, mock_user_owns, mock_user_is_member
-    ):
+    def test_resource_delete(self, mock_get_resource, mock_user_owns):
         """
         Test ckanext.userdatasets.logic.auth.create.resource_delete.
 
@@ -320,20 +299,18 @@ class TestAuthActionsUnit(object):
         """
         tests = [
             {'user_owns': True, 'user_is_member': True, 'result': {'success': True}},
-            {'user_owns': False, 'user_is_member': True, 'result': {'success': False}},
+            {'user_owns': False, 'user_is_member': True, 'result': 'fallback'},
             {'user_owns': False, 'user_is_member': False, 'result': 'fallback'},
         ]
         mock_get_resource.return_value = MagicMock(package=1)
         for t in tests:
             mock_user_owns.return_value = t['user_owns']
-            mock_user_is_member.return_value = t['user_is_member']
             mock_default_auth = MagicMock(return_value='fallback')
             assert (
                 resource_delete(mock_default_auth, {'auth_user_obj': 1}, {})
                 == t['result']
             )
 
-    @patch('ckanext.userdatasets.logic.auth.delete.user_is_member_of_package_org')
     @patch('ckanext.userdatasets.logic.auth.delete.user_owns_package_as_member')
     @patch('ckanext.userdatasets.logic.auth.delete.get_resource_object')
     @patch('ckanext.userdatasets.logic.auth.delete.get_resource_view_object')
@@ -342,7 +319,6 @@ class TestAuthActionsUnit(object):
         mock_get_resource_view,
         mock_get_resource,
         mock_user_owns,
-        mock_user_is_member,
     ):
         """
         Test ckanext.userdatasets.logic.auth.create.resource_view_delete.
@@ -351,14 +327,13 @@ class TestAuthActionsUnit(object):
         """
         tests = [
             {'user_owns': True, 'user_is_member': True, 'result': {'success': True}},
-            {'user_owns': False, 'user_is_member': True, 'result': {'success': False}},
+            {'user_owns': False, 'user_is_member': True, 'result': 'fallback'},
             {'user_owns': False, 'user_is_member': False, 'result': 'fallback'},
         ]
         mock_get_resource_view.return_value = MagicMock(resource_id=1)
         mock_get_resource.return_value = MagicMock(package=1)
         for t in tests:
             mock_user_owns.return_value = t['user_owns']
-            mock_user_is_member.return_value = t['user_is_member']
             mock_default_auth = MagicMock(return_value='fallback')
             result = resource_view_delete(
                 mock_default_auth, {'auth_user_obj': 1}, {'resource_id': 1}

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -192,13 +192,13 @@ class TestFuncResourceViews(object):
         assert resource_view_updated['description'] == new_desc
         assert resource_view['description'] != resource_view_updated['description']
 
-    def test_members_cannot_edit_others_resource_views(self, org, member_1, member_2):
+    def test_members_no_special_privileges(self, org, member_1, member_2):
         package = create_package(org, member_1)
         resource = factories.Resource(package_id=package['id'])
         resource_view = factories.ResourceView(resource_id=resource['id'])
 
         context = {'user': member_2['name']}
-        new_desc = 'description for test_members_cannot_edit_others_resource_views'
+        new_desc = 'description for test_members_no_special_privileges'
 
         with pytest.raises(toolkit.NotAuthorized):
             toolkit.get_action('resource_view_update')(


### PR DESCRIPTION
If the user is just a regular member of the org, their permissions can be handled by other extensions or core CKAN rather than overriding any chained auth and setting to False (which overrides all collaborator permissions).

Closes: #38
