### PR TITLE
Collaborator management permissions

### DIFF
--- a/ckanext/userdatasets/logic/action/create.py
+++ b/ckanext/userdatasets/logic/action/create.py
@@ -9,12 +9,14 @@ import logging
 import ckan.lib.plugins as lib_plugins
 from ckan.logic.validators import owner_org_validator as default_owner_org_validator
 from ckan.plugins import toolkit
+from ckantools.decorators import basic_action
 
 from ckanext.userdatasets.logic.validators import owner_org_validator
 
 log = logging.getLogger('ckanext.userdatasets')
 
 
+@basic_action
 @toolkit.chained_action
 def package_create(next_action, context, data_dict):
     package_type = data_dict.get('type')

--- a/ckanext/userdatasets/logic/action/get.py
+++ b/ckanext/userdatasets/logic/action/get.py
@@ -5,8 +5,10 @@
 # Created by the Natural History Museum in London, UK
 
 from ckan.plugins import toolkit
+from ckantools.decorators import basic_action
 
 
+@basic_action
 @toolkit.chained_action
 def organization_list_for_user(next_action, context, data_dict):
     perm = data_dict.get('permission')

--- a/ckanext/userdatasets/logic/action/update.py
+++ b/ckanext/userdatasets/logic/action/update.py
@@ -9,12 +9,14 @@ import logging
 import ckan.lib.plugins as lib_plugins
 from ckan.logic.validators import owner_org_validator as default_owner_org_validator
 from ckan.plugins import toolkit
+from ckantools.decorators import basic_action
 
 from ckanext.userdatasets.logic.validators import owner_org_validator
 
 log = logging.getLogger('ckanext.userdatasets')
 
 
+@basic_action
 @toolkit.chained_action
 def package_update(next_action, context, data_dict):
     model = context['model']

--- a/ckanext/userdatasets/logic/auth/create.py
+++ b/ckanext/userdatasets/logic/auth/create.py
@@ -7,12 +7,14 @@
 from ckan.authz import has_user_permission_for_some_org, users_role_for_group_or_org
 from ckan.logic.auth import get_package_object, get_resource_object
 from ckan.plugins import toolkit
+from ckantools.decorators import auth
 
 from ckanext.userdatasets.logic.auth.auth import (
     user_owns_package_as_member,
 )
 
 
+@auth()
 @toolkit.chained_auth_function
 def package_create(next_auth, context, data_dict):
     user = context['auth_user_obj']
@@ -31,6 +33,7 @@ def package_create(next_auth, context, data_dict):
     return next_auth(context, data_dict)
 
 
+@auth()
 @toolkit.chained_auth_function
 def resource_create(next_auth, context, data_dict):
     user = context['auth_user_obj']
@@ -51,6 +54,7 @@ def resource_create(next_auth, context, data_dict):
     return next_auth(context, data_dict)
 
 
+@auth()
 @toolkit.chained_auth_function
 def resource_view_create(next_auth, context, data_dict):
     user = context['auth_user_obj']

--- a/ckanext/userdatasets/logic/auth/create.py
+++ b/ckanext/userdatasets/logic/auth/create.py
@@ -72,3 +72,16 @@ def resource_view_create(next_auth, context, data_dict):
         return {'success': True}
 
     return next_auth(context, data_dict)
+
+
+@auth()
+@toolkit.chained_auth_function
+def package_collaborator_create(next_auth, context, data_dict):
+    user = context['auth_user_obj']
+
+    package_id = data_dict.get('id')
+    package = get_package_object(context, {'id': package_id})
+    if user_owns_package_as_member(user, package):
+        return {'success': True}
+
+    return next_auth(context, data_dict)

--- a/ckanext/userdatasets/logic/auth/delete.py
+++ b/ckanext/userdatasets/logic/auth/delete.py
@@ -48,3 +48,16 @@ def resource_view_delete(next_auth, context, data_dict):
         return {'success': True}
 
     return next_auth(context, data_dict)
+
+
+@auth()
+@toolkit.chained_auth_function
+def package_collaborator_delete(next_auth, context, data_dict):
+    user = context['auth_user_obj']
+
+    package_id = data_dict.get('id')
+    package = get_package_object(context, {'id': package_id})
+    if user_owns_package_as_member(user, package):
+        return {'success': True}
+
+    return next_auth(context, data_dict)

--- a/ckanext/userdatasets/logic/auth/delete.py
+++ b/ckanext/userdatasets/logic/auth/delete.py
@@ -6,6 +6,7 @@
 
 from ckan.logic.auth import get_package_object, get_resource_object
 from ckan.plugins import toolkit
+from ckantools.decorators import auth
 
 from ckanext.userdatasets.logic.auth.auth import (
     get_resource_view_object,
@@ -13,6 +14,7 @@ from ckanext.userdatasets.logic.auth.auth import (
 )
 
 
+@auth()
 @toolkit.chained_auth_function
 def package_delete(next_auth, context, data_dict):
     user = context['auth_user_obj']
@@ -24,6 +26,7 @@ def package_delete(next_auth, context, data_dict):
     return next_auth(context, data_dict)
 
 
+@auth()
 @toolkit.chained_auth_function
 def resource_delete(next_auth, context, data_dict):
     user = context['auth_user_obj']
@@ -35,6 +38,7 @@ def resource_delete(next_auth, context, data_dict):
     return next_auth(context, data_dict)
 
 
+@auth()
 @toolkit.chained_auth_function
 def resource_view_delete(next_auth, context, data_dict):
     user = context['auth_user_obj']

--- a/ckanext/userdatasets/logic/auth/get.py
+++ b/ckanext/userdatasets/logic/auth/get.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+#
+# This file is part of ckanext-userdatasets
+# Created by the Natural History Museum in London, UK
+
+from ckan.logic.auth import get_package_object
+from ckan.plugins import toolkit
+from ckantools.decorators import auth
+
+from ckanext.userdatasets.logic.auth.auth import (
+    user_owns_package_as_member,
+)
+
+
+@auth()
+@toolkit.chained_auth_function
+def package_collaborator_list(next_auth, context, data_dict):
+    user = context['auth_user_obj']
+
+    package_id = data_dict.get('id')
+    package = get_package_object(context, {'id': package_id})
+    if user_owns_package_as_member(user, package):
+        return {'success': True}
+
+    return next_auth(context, data_dict)

--- a/ckanext/userdatasets/logic/auth/update.py
+++ b/ckanext/userdatasets/logic/auth/update.py
@@ -6,6 +6,7 @@
 
 from ckan.logic.auth import get_package_object, get_resource_object
 from ckan.plugins import toolkit
+from ckantools.decorators import auth
 
 from ckanext.userdatasets.logic.auth.auth import (
     get_resource_view_object,
@@ -13,6 +14,7 @@ from ckanext.userdatasets.logic.auth.auth import (
 )
 
 
+@auth()
 @toolkit.chained_auth_function
 def package_update(next_auth, context, data_dict):
     user = context['auth_user_obj']
@@ -23,6 +25,7 @@ def package_update(next_auth, context, data_dict):
     return next_auth(context, data_dict)
 
 
+@auth()
 @toolkit.chained_auth_function
 def resource_update(next_auth, context, data_dict):
     user = context['auth_user_obj']
@@ -34,6 +37,7 @@ def resource_update(next_auth, context, data_dict):
     return next_auth(context, data_dict)
 
 
+@auth()
 @toolkit.chained_auth_function
 def resource_view_update(next_auth, context, data_dict):
     user = context['auth_user_obj']

--- a/ckanext/userdatasets/plugin.py
+++ b/ckanext/userdatasets/plugin.py
@@ -4,9 +4,9 @@
 # This file is part of ckanext-userdatasets
 # Created by the Natural History Museum in London, UK
 
-import importlib
 
 from ckan.plugins import SingletonPlugin, implements, interfaces
+from ckantools.loaders import create_actions, create_auth
 
 
 class UserDatasetsPlugin(SingletonPlugin):
@@ -21,36 +21,22 @@ class UserDatasetsPlugin(SingletonPlugin):
     implements(interfaces.IAuthFunctions)
     implements(interfaces.IActions)
 
+    # IAuthFunctions
     def get_auth_functions(self):
         """
         Implementation of IAuthFunctions.get_auth_functions.
         """
-        auth_functions = {}
-        for action in ['create', 'update', 'delete']:
-            uds_module = importlib.import_module(
-                'ckanext.userdatasets.logic.auth.' + action
-            )
-            for atype in ['package', 'resource', 'resource_view']:
-                fn_name = atype + '_' + action
-                if hasattr(uds_module, fn_name):
-                    auth_functions[fn_name] = getattr(uds_module, fn_name)
-        return auth_functions
+        from ckanext.userdatasets.logic.auth import create, delete, update
 
+        auth = create_auth(create, delete, update)
+        return auth
+
+    # IActions
     def get_actions(self):
         """
         Implementation of IActions.get_actions.
         """
-        actions = {}
-        # Override selected actions.
-        to_override = {
-            'create': ['package_create'],
-            'update': ['package_update'],
-            'get': ['organization_list_for_user'],
-        }
-        for action_type, action in to_override.items():
-            uds_module = importlib.import_module(
-                'ckanext.userdatasets.logic.action.' + action_type
-            )
-            for fn_name in action:
-                actions[fn_name] = getattr(uds_module, fn_name)
+        from ckanext.userdatasets.logic.action import create, get, update
+
+        actions = create_actions(create, get, update)
         return actions

--- a/ckanext/userdatasets/plugin.py
+++ b/ckanext/userdatasets/plugin.py
@@ -26,9 +26,9 @@ class UserDatasetsPlugin(SingletonPlugin):
         """
         Implementation of IAuthFunctions.get_auth_functions.
         """
-        from ckanext.userdatasets.logic.auth import create, delete, update
+        from ckanext.userdatasets.logic.auth import create, delete, get, update
 
-        auth = create_auth(create, delete, update)
+        auth = create_auth(create, delete, update, get)
         return auth
 
     # IActions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8"
 ]
 dependencies = [
-    "ckantools>=0.4.1"
+    "ckantools>=0.4.2"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Chains auth functions for:
- `package_collaborator_list`
- `package_collaborator_create`
- `package_collaborator_delete`

To allow dataset owners to manage collaborators on their own datasets. Dataset owners still need to be a member of the organisation that owns the dataset.
