### PR TITLE
Accept org admins and editors as members

### DIFF
--- a/ckanext/userdatasets/logic/auth/auth.py
+++ b/ckanext/userdatasets/logic/auth/auth.py
@@ -4,36 +4,35 @@
 # This file is part of ckanext-userdatasets
 # Created by the Natural History Museum in London, UK
 
-from ckan.authz import users_role_for_group_or_org
 from ckan.plugins import toolkit
+
+from ckanext.userdatasets.logic.utils import org_role_is_valid
 
 
 def user_is_member_of_package_org(user, package):
     """
-    Return True if the package is in an organization and the user has the member role in
-    that organization.
+    Return True if the package is in an organisation and the user has a valid role in
+    that organisation.
 
     :param user: A user object
     :param package: A package object
-    :returns: True if the user has the 'member' role in the organization that owns the
+    :returns: True if the user has a valid role in the organisation that owns the
         package, False otherwise
     """
-    if package.owner_org:
-        role_in_org = users_role_for_group_or_org(package.owner_org, user.name)
-        if role_in_org == 'member':
-            return True
-    return False
+    return package.owner_org is not None and org_role_is_valid(
+        package.owner_org, user.name
+    )
 
 
 def user_owns_package_as_member(user, package):
     """
-    Checks that the given user created the package, and has the 'member' role in the
-    organization that owns the package.
+    Checks that the given user created the package, and has a valid role in the
+    organisation that owns the package.
 
     :param user: A user object
     :param package: A package object
-    :returns: True if the user created the package and has the 'member' role in the
-        organization to which package belongs. False otherwise.
+    :returns: True if the user created the package and has a valid role in the
+        organisation to which package belongs. False otherwise.
     """
     if user_is_member_of_package_org(user, package):
         return package.creator_user_id and user.id == package.creator_user_id

--- a/ckanext/userdatasets/logic/auth/auth.py
+++ b/ckanext/userdatasets/logic/auth/auth.py
@@ -19,9 +19,7 @@ def user_is_member_of_package_org(user, package):
     :returns: True if the user has a valid role in the organisation that owns the
         package, False otherwise
     """
-    return package.owner_org is not None and org_role_is_valid(
-        package.owner_org, user.name
-    )
+    return package.owner_org and org_role_is_valid(package.owner_org, user.name)
 
 
 def user_owns_package_as_member(user, package):

--- a/ckanext/userdatasets/logic/auth/auth.py
+++ b/ckanext/userdatasets/logic/auth/auth.py
@@ -19,7 +19,7 @@ def user_is_member_of_package_org(user, package):
     :returns: True if the user has a valid role in the organisation that owns the
         package, False otherwise
     """
-    return package.owner_org and org_role_is_valid(package.owner_org, user.name)
+    return bool(package.owner_org) and org_role_is_valid(package.owner_org, user.name)
 
 
 def user_owns_package_as_member(user, package):

--- a/ckanext/userdatasets/logic/auth/create.py
+++ b/ckanext/userdatasets/logic/auth/create.py
@@ -4,7 +4,7 @@
 # This file is part of ckanext-userdatasets
 # Created by the Natural History Museum in London, UK
 
-from ckan.authz import has_user_permission_for_some_org, users_role_for_group_or_org
+from ckan.authz import has_user_permission_for_some_org
 from ckan.logic.auth import get_package_object, get_resource_object
 from ckan.plugins import toolkit
 from ckantools.decorators import auth
@@ -12,6 +12,7 @@ from ckantools.decorators import auth
 from ckanext.userdatasets.logic.auth.auth import (
     user_owns_package_as_member,
 )
+from ckanext.userdatasets.logic.utils import org_role_is_valid
 
 
 @auth()
@@ -19,8 +20,7 @@ from ckanext.userdatasets.logic.auth.auth import (
 def package_create(next_auth, context, data_dict):
     user = context['auth_user_obj']
     if data_dict and 'owner_org' in data_dict:
-        role = users_role_for_group_or_org(data_dict['owner_org'], user.name)
-        if role == 'member':
+        if org_role_is_valid(data_dict['owner_org'], user.name):
             return {'success': True}
     else:
         # If there is no organisation, then this should return success if the user can

--- a/ckanext/userdatasets/logic/utils.py
+++ b/ckanext/userdatasets/logic/utils.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+#
+# This file is part of ckanext-userdatasets
+# Created by the Natural History Museum in London, UK
+
+from ckan.authz import users_role_for_group_or_org
+
+
+def org_role_is_valid(group_or_org_id, username):
+    """
+    Determine whether the given user has a valid role in the specified group or
+    organisation.
+
+    :param group_or_org_id: ID of a group or organisation
+    :param username: username for the user to check
+    :returns: True if the role is valid (member, editor, or admin), False otherwise
+    :rtype: bool
+    """
+    role = users_role_for_group_or_org(group_or_org_id, username)
+    return role in ['member', 'editor', 'admin']

--- a/ckanext/userdatasets/logic/validators.py
+++ b/ckanext/userdatasets/logic/validators.py
@@ -4,9 +4,10 @@
 # This file is part of ckanext-userdatasets
 # Created by the Natural History Museum in London, UK
 
-from ckan.authz import users_role_for_group_or_org
 from ckan.logic.validators import owner_org_validator as default_owner_org_validator
 from ckan.plugins import toolkit
+
+from ckanext.userdatasets.logic.utils import org_role_is_valid
 
 
 def owner_org_validator(key, data, errors, context):
@@ -17,8 +18,7 @@ def owner_org_validator(key, data, errors, context):
         else:
             username = context['user']
 
-        role = users_role_for_group_or_org(owner_org, username)
-        if role == 'member':
+        if org_role_is_valid(owner_org, username):
             return
 
     default_owner_org_validator(key, data, errors, context)

--- a/tests/test_auth_actions_unit.py
+++ b/tests/test_auth_actions_unit.py
@@ -35,7 +35,7 @@ class TestAuthActionsUnit(object):
     Perform unit tests on the auth functions in ckanext.userdatasets.logic.auth.
     """
 
-    @patch('ckanext.userdatasets.logic.auth.auth.users_role_for_group_or_org')
+    @patch('ckanext.userdatasets.logic.utils.users_role_for_group_or_org')
     def test_user_is_member_of_package_org(self, mock_users_role):
         """
         Test ckanext.userdatasets.logic.auth.auth.user_is_member_of_package_org.
@@ -54,6 +54,18 @@ class TestAuthActionsUnit(object):
                 'package': MagicMock(owner_org='carrot'),
                 'user': MagicMock(name='turtle'),
                 'role': 'editor',
+                'result': True,
+            },
+            {
+                'package': MagicMock(owner_org='carrot'),
+                'user': MagicMock(name='turtle'),
+                'role': 'admin',
+                'result': True,
+            },
+            {
+                'package': MagicMock(owner_org='carrot'),
+                'user': MagicMock(name='turtle'),
+                'role': None,
                 'result': False,
             },
             {
@@ -67,7 +79,7 @@ class TestAuthActionsUnit(object):
             mock_users_role.return_value = t['role']
             assert user_is_member_of_package_org(t['user'], t['package']) == t['result']
 
-    @patch('ckanext.userdatasets.logic.auth.auth.users_role_for_group_or_org')
+    @patch('ckanext.userdatasets.logic.utils.users_role_for_group_or_org')
     def test_user_owns_package_as_member(self, mock_users_role):
         """
         Test ckanext.userdatasets.logic.auth.auth.user_owns_package_as_member.
@@ -83,6 +95,12 @@ class TestAuthActionsUnit(object):
                 'result': True,
             },
             {
+                'user': MagicMock(id=444, name='turtle'),
+                'package': MagicMock(creator_user_id=444, owner_org='carrot'),
+                'role': 'editor',
+                'result': True,
+            },
+            {
                 'user': MagicMock(id=445, name='turtle'),
                 'package': MagicMock(creator_user_id=444, owner_org='carrot'),
                 'role': 'member',
@@ -90,14 +108,14 @@ class TestAuthActionsUnit(object):
             },
             {
                 'user': MagicMock(id=444, name='turtle'),
-                'package': MagicMock(creator_user_id=444, owner_org=False),
+                'package': MagicMock(creator_user_id=444, owner_org=None),
                 'role': 'member',
                 'result': False,
             },
             {
                 'user': MagicMock(id=444, name='turtle'),
                 'package': MagicMock(creator_user_id=444, owner_org='carrot'),
-                'role': 'editor',
+                'role': None,
                 'result': False,
             },
         ]
@@ -105,7 +123,7 @@ class TestAuthActionsUnit(object):
             mock_users_role.return_value = t['role']
             assert user_owns_package_as_member(t['user'], t['package']) == t['result']
 
-    @patch('ckanext.userdatasets.logic.auth.create.users_role_for_group_or_org')
+    @patch('ckanext.userdatasets.logic.utils.users_role_for_group_or_org')
     @patch('ckanext.userdatasets.logic.auth.create.has_user_permission_for_some_org')
     def test_package_create(self, mock_has_perm, mock_users_role):
         """
@@ -126,6 +144,13 @@ class TestAuthActionsUnit(object):
                 'context': {'auth_user_obj': MagicMock(name='turtle')},
                 'data_dict': {'owner_org': 'carrot'},
                 'role': 'editor',
+                'has_perm': True,
+                'result': {'success': True},
+            },
+            {
+                'context': {'auth_user_obj': MagicMock(name='turtle')},
+                'data_dict': {'owner_org': 'carrot'},
+                'role': None,
                 'has_perm': True,
                 'result': 'fallback',
             },

--- a/tests/test_auth_actions_unit.py
+++ b/tests/test_auth_actions_unit.py
@@ -74,6 +74,18 @@ class TestAuthActionsUnit(object):
                 'role': 'member',
                 'result': False,
             },
+            {
+                'package': MagicMock(owner_org=''),
+                'user': MagicMock(name='turtle'),
+                'role': 'member',
+                'result': False,
+            },
+            {
+                'package': MagicMock(owner_org=False),
+                'user': MagicMock(name='turtle'),
+                'role': 'member',
+                'result': False,
+            },
         ]
         for t in tests:
             mock_users_role.return_value = t['role']


### PR DESCRIPTION
They're still part of the organisation, so they should get the same permission overrides.

Closes: #46